### PR TITLE
HOTFIX: FIX Content Menu link Problem.

### DIFF
--- a/sites/all/modules/features/menus/menus.install
+++ b/sites/all/modules/features/menus/menus.install
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Install file for the menu feature.
+ */
+
+/**
+ * Fix the Content menu links.
+ */
+function menus_update_7000() {
+  $query = db_select('menu_links', 'm')
+    ->fields('m', array('mlid'))
+    ->condition('menu_name', 'navigation')
+    ->condition('router_path', 'node/add')
+    ->execute();
+  $result = $query->fetchCol();
+  $to_delete = array();
+  if (count($result > 1)) {
+    $min_value = min($result);
+    foreach ($result as $key => $mlid) {
+      if ($mlid === $min_value) {
+        continue;
+      }
+      $to_delete[] = $mlid;
+    }
+  }
+  if (count($to_delete)) {
+    db_delete('menu_links')
+      ->condition('mlid', $to_delete, 'IN')
+      ->execute();
+  }
+}


### PR DESCRIPTION
Steps to test:
- `drush updb -y; drush master-scope local; drush master-execute -y;  drush cc all`
-  Create a test content type.
- Go to the admin menu in to the Content section, the add content menu should be there , and fully functional
