### PR TITLE
Se agregan nuevas taxonomias para ser utilizadas en el tipo de conten…

### DIFF
--- a/sites/all/modules/features/vocabularios/vocabularios.features.inc
+++ b/sites/all/modules/features/vocabularios/vocabularios.features.inc
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @file
+ * vocabularios.features.inc
+ */
+
+/**
+ * Implements hook_ctools_plugin_api().
+ */
+function vocabularios_ctools_plugin_api($module = NULL, $api = NULL) {
+  if ($module == "strongarm" && $api == "strongarm") {
+    return array("version" => "1");
+  }
+}

--- a/sites/all/modules/features/vocabularios/vocabularios.strongarm.inc
+++ b/sites/all/modules/features/vocabularios/vocabularios.strongarm.inc
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @file
+ * vocabularios.strongarm.inc
+ */
+
+/**
+ * Implements hook_strongarm().
+ */
+function vocabularios_strongarm() {
+  $export = array();
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'pathauto_taxonomy_term_lista_2_pattern';
+  $strongarm->value = '';
+  $export['pathauto_taxonomy_term_lista_2_pattern'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'pathauto_taxonomy_term_lista_3_pattern';
+  $strongarm->value = '';
+  $export['pathauto_taxonomy_term_lista_3_pattern'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'pathauto_taxonomy_term_rol_pattern';
+  $strongarm->value = '';
+  $export['pathauto_taxonomy_term_rol_pattern'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'pathauto_taxonomy_term_tipo_instancia_pattern';
+  $strongarm->value = '';
+  $export['pathauto_taxonomy_term_tipo_instancia_pattern'] = $strongarm;
+
+  return $export;
+}


### PR DESCRIPTION
Se agregaron nuevas taxonomías correspondientes al tipo de instancia y tipo de subinstancia de coordinación para ser utilizadas en el tipo de contenido instancias de coordinación.