### PR TITLE
PGE: Switched positions of the views in the Emergency Decrees panel

### DIFF
--- a/sites/all/modules/features/monitorsngr_pge/monitorsngr_pge.pages_default.inc
+++ b/sites/all/modules/features/monitorsngr_pge/monitorsngr_pge.pages_default.inc
@@ -916,48 +916,6 @@ function monitorsngr_pge_default_page_manager_handlers() {
   $display->content['new-69a6b3ba-2483-4ea6-adf7-c2866182903a'] = $pane;
   $display->panels['middle'][7] = 'new-69a6b3ba-2483-4ea6-adf7-c2866182903a';
   $pane = new stdClass();
-  $pane->pid = 'new-f7958d78-831d-46bd-8f19-4efbab01d4e7';
-  $pane->panel = 'middle';
-  $pane->type = 'add_compro_button';
-  $pane->subtype = 'add_compro_button';
-  $pane->shown = TRUE;
-  $pane->access = array();
-  $pane->configuration = array();
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-  );
-  $pane->css = array();
-  $pane->extras = array();
-  $pane->position = 8;
-  $pane->locks = array();
-  $pane->uuid = 'f7958d78-831d-46bd-8f19-4efbab01d4e7';
-  $display->content['new-f7958d78-831d-46bd-8f19-4efbab01d4e7'] = $pane;
-  $display->panels['middle'][8] = 'new-f7958d78-831d-46bd-8f19-4efbab01d4e7';
-  $pane = new stdClass();
-  $pane->pid = 'new-0df71b7a-4a46-4b2e-b8c3-b01b52ce016c';
-  $pane->panel = 'middle';
-  $pane->type = 'views_panes';
-  $pane->subtype = 'compromisos_pge-panel_pane_1';
-  $pane->shown = TRUE;
-  $pane->access = array();
-  $pane->configuration = array(
-    'arguments' => array(
-      'field_decreto_emergencia_target_id' => '%node:nid',
-    ),
-  );
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-  );
-  $pane->css = array();
-  $pane->extras = array();
-  $pane->position = 9;
-  $pane->locks = array();
-  $pane->uuid = '0df71b7a-4a46-4b2e-b8c3-b01b52ce016c';
-  $display->content['new-0df71b7a-4a46-4b2e-b8c3-b01b52ce016c'] = $pane;
-  $display->panels['middle'][9] = 'new-0df71b7a-4a46-4b2e-b8c3-b01b52ce016c';
-  $pane = new stdClass();
   $pane->pid = 'new-8b8add00-3a15-40f3-aece-171a9bf258b0';
   $pane->panel = 'middle';
   $pane->type = 'add_form_button';
@@ -971,11 +929,11 @@ function monitorsngr_pge_default_page_manager_handlers() {
   );
   $pane->css = array();
   $pane->extras = array();
-  $pane->position = 10;
+  $pane->position = 8;
   $pane->locks = array();
   $pane->uuid = '8b8add00-3a15-40f3-aece-171a9bf258b0';
   $display->content['new-8b8add00-3a15-40f3-aece-171a9bf258b0'] = $pane;
-  $display->panels['middle'][10] = 'new-8b8add00-3a15-40f3-aece-171a9bf258b0';
+  $display->panels['middle'][8] = 'new-8b8add00-3a15-40f3-aece-171a9bf258b0';
   $pane = new stdClass();
   $pane->pid = 'new-1c719fb9-66f6-413d-bb31-c95a7adff46a';
   $pane->panel = 'middle';
@@ -994,11 +952,53 @@ function monitorsngr_pge_default_page_manager_handlers() {
   );
   $pane->css = array();
   $pane->extras = array();
-  $pane->position = 11;
+  $pane->position = 9;
   $pane->locks = array();
   $pane->uuid = '1c719fb9-66f6-413d-bb31-c95a7adff46a';
   $display->content['new-1c719fb9-66f6-413d-bb31-c95a7adff46a'] = $pane;
-  $display->panels['middle'][11] = 'new-1c719fb9-66f6-413d-bb31-c95a7adff46a';
+  $display->panels['middle'][9] = 'new-1c719fb9-66f6-413d-bb31-c95a7adff46a';
+  $pane = new stdClass();
+  $pane->pid = 'new-f7958d78-831d-46bd-8f19-4efbab01d4e7';
+  $pane->panel = 'middle';
+  $pane->type = 'add_compro_button';
+  $pane->subtype = 'add_compro_button';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array();
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array();
+  $pane->extras = array();
+  $pane->position = 10;
+  $pane->locks = array();
+  $pane->uuid = 'f7958d78-831d-46bd-8f19-4efbab01d4e7';
+  $display->content['new-f7958d78-831d-46bd-8f19-4efbab01d4e7'] = $pane;
+  $display->panels['middle'][10] = 'new-f7958d78-831d-46bd-8f19-4efbab01d4e7';
+  $pane = new stdClass();
+  $pane->pid = 'new-0df71b7a-4a46-4b2e-b8c3-b01b52ce016c';
+  $pane->panel = 'middle';
+  $pane->type = 'views_panes';
+  $pane->subtype = 'compromisos_pge-panel_pane_1';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array(
+    'arguments' => array(
+      'field_decreto_emergencia_target_id' => '%node:nid',
+    ),
+  );
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array();
+  $pane->extras = array();
+  $pane->position = 11;
+  $pane->locks = array();
+  $pane->uuid = '0df71b7a-4a46-4b2e-b8c3-b01b52ce016c';
+  $display->content['new-0df71b7a-4a46-4b2e-b8c3-b01b52ce016c'] = $pane;
+  $display->panels['middle'][11] = 'new-0df71b7a-4a46-4b2e-b8c3-b01b52ce016c';
   $display->hide_title = PANELS_TITLE_PANE;
   $display->title_pane = 'new-54929c30-b44b-4fbd-82c9-d473c506e0d8';
   $handler->conf['display'] = $display;


### PR DESCRIPTION
Steps to test:
- `drush master-scope local; drush master-execute -y; drush fra -y; drush cc all`
- Go to an emergency decree page (`decreto/decreto_emergencia_proteger_dengue_chikungunya_zika`)
- You should see the view and button for the _supply forms_ first 
-  And bellow , the  view and button for the _compromises_
