### PR TITLE
Permisos del pdf para todos los usuarios agregados

### DIFF
--- a/sites/all/modules/features/usuarios_roles_permisos/usuarios_roles_permisos.features.user_permission.inc
+++ b/sites/all/modules/features/usuarios_roles_permisos/usuarios_roles_permisos.features.user_permission.inc
@@ -15,6 +15,8 @@ function usuarios_roles_permisos_user_default_permissions() {
     'name' => 'access PDF version',
     'roles' => array(
       'administrator' => 'administrator',
+      'anonymous user' => 'anonymous user',
+      'authenticated user' => 'authenticated user',
     ),
     'module' => 'print_pdf',
   );


### PR DESCRIPTION
Se agregaron los permisos para que cualquier usuario pueda ver los link para ver las versiones pdf de los contenidos del sitio.