### PR TITLE
Agregar la extensión telefónica a una Institución y a la Cuenta de us…

### DIFF
--- a/sites/all/modules/features/sngr_field_bases/sngr_field_bases.features.field_base.inc
+++ b/sites/all/modules/features/sngr_field_bases/sngr_field_bases.features.field_base.inc
@@ -1149,6 +1149,30 @@ function sngr_field_bases_field_default_field_bases() {
     'type' => 'number_float',
   );
 
+  // Exported field_base: 'field_extension_telefonica'.
+  $field_bases['field_extension_telefonica'] = array(
+    'active' => 1,
+    'cardinality' => 1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'field_extension_telefonica',
+    'field_permissions' => array(
+      'type' => 0,
+    ),
+    'indexes' => array(
+      'format' => array(
+        0 => 'format',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'text',
+    'settings' => array(
+      'max_length' => 50,
+    ),
+    'translatable' => 0,
+    'type' => 'text',
+  );
+
   // Exported field_base: 'field_fase'.
   $field_bases['field_fase'] = array(
     'active' => 1,

--- a/sites/all/modules/features/sngr_field_bases/sngr_field_bases.features.field_instance.inc
+++ b/sites/all/modules/features/sngr_field_bases/sngr_field_bases.features.field_instance.inc
@@ -35,7 +35,7 @@ function sngr_field_bases_field_default_field_instances() {
     'entity_type' => 'field_collection_item',
     'field_name' => 'field_descripc_fuente_verifica',
     'label' => 'Descripción de la Fuente de Verificación',
-    'required' => 1,
+    'required' => 0,
     'settings' => array(
       'text_processing' => 0,
       'user_register_form' => FALSE,

--- a/sites/all/modules/features/sngr_field_bases/sngr_field_bases.info
+++ b/sites/all/modules/features/sngr_field_bases/sngr_field_bases.info
@@ -82,6 +82,7 @@ features[field_base][] = field_estado
 features[field_base][] = field_evaluar_metas
 features[field_base][] = field_evaluar_producto
 features[field_base][] = field_extension
+features[field_base][] = field_extension_telefonica
 features[field_base][] = field_fase
 features[field_base][] = field_fecha
 features[field_base][] = field_fecha_finiquito


### PR DESCRIPTION
Agregar la extensión telefónica a una Institución y a la Cuenta de usuario. Además hace no obligatorio el campo Descripción de una fuente de verificación de un producto dentro de un compromiso de gestión.